### PR TITLE
Editor sensitivity setting in Editor Preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@
 *Havtorn/BuildFiles
 *Havtorn/ProjectSetup/SetupRequirements/
 *Havtorn/Source/__pycache__
+*Havtorn/Bin/Config/EditorPreferences.user.json
 
 # Other/Intermediate
 *.ilk

--- a/Havtorn/Bin/Config/EditorPreferences.json
+++ b/Havtorn/Bin/Config/EditorPreferences.json
@@ -1,0 +1,4 @@
+{
+    "Sensitivity": 0.5,
+    "Color Theme": 1
+}

--- a/Havtorn/Source/Core/FileSystem.h
+++ b/Havtorn/Source/Core/FileSystem.h
@@ -80,7 +80,7 @@ namespace Havtorn
 
 		template<typename T>
 		T Get(const std::string& memberName, const T& defaultValue) const;
-		template <class T>
+		template<typename T>
 		void Set(const std::string& memberName, const T& newValue);
 
 	private:

--- a/Havtorn/Source/Core/FileSystem.h
+++ b/Havtorn/Source/Core/FileSystem.h
@@ -80,11 +80,12 @@ namespace Havtorn
 
 		template<typename T>
 		T Get(const std::string& memberName, const T& defaultValue) const;
+		template <class T>
+		void Set(const std::string& memberName, const T& newValue);
 
 	private:
 		CORE_API void SaveFile();
 
-	private:
 		rapidjson::Document Document;
 		std::string FilePath = "";
 	};
@@ -96,6 +97,16 @@ namespace Havtorn
 			return defaultValue;
 
 		return Document[memberName.c_str()].Get<T>();
+	}
+	
+	template<typename T>
+	void CJsonDocument::Set(const std::string& memberName, const T& newValue)
+	{
+		if (!HasMember(memberName))	
+			return;
+		
+		Document[memberName.c_str()].Set<T>(newValue);
+		SaveFile();
 	}
 
 	class UFileSystem

--- a/Havtorn/Source/Editor/EditorManager.cpp
+++ b/Havtorn/Source/Editor/EditorManager.cpp
@@ -207,9 +207,9 @@ namespace Havtorn
 			GUI::End();
 		}
 		
-		if (IsPreferenesOpen)
+		if (IsPreferencesOpen)
 		{
-			if (GUI::Begin("Editor Preferences", &IsPreferenesOpen))
+			if (GUI::Begin("Editor Preferences", &IsPreferencesOpen))
 			{
 				F32 sensitivity = GetEditorSensitivity();
 				if (GUI::DragFloat("Editor Sensitivity", sensitivity, 0.01f, 0.01f, 5.0f))
@@ -506,7 +506,7 @@ namespace Havtorn
 	{
 		if (EditorPreferences.ColorTheme != colorTheme)
 		{
-			EditorPreferencesDocument.Set("Color Theme", static_cast<int>(colorTheme));
+			EditorPreferencesDocument.Set("Color Theme", STATIC_I32(colorTheme));
 			
 		}
 		EditorPreferences.ColorTheme = colorTheme;
@@ -730,7 +730,7 @@ namespace Havtorn
 		return EditorPreferences.Sensitivity;
 	}
 
-	void CEditorManager::SetEditorSensitivity(F32 sensitivity)
+	void CEditorManager::SetEditorSensitivity(const F32 sensitivity)
 	{
 		EditorPreferences.Sensitivity = sensitivity;
 		EditorPreferencesDocument.Set("Sensitivity", EditorPreferences.Sensitivity);
@@ -779,7 +779,7 @@ namespace Havtorn
 	
 	void CEditorManager::TogglePreferences()
 	{
-		IsPreferenesOpen = !IsPreferenesOpen;
+		IsPreferencesOpen = !IsPreferencesOpen;
 	}
 
 	void CEditorManager::InitEditorLayout()
@@ -901,14 +901,14 @@ namespace Havtorn
 
 	void CEditorManager::InitEditorPreferences()
 	{
-		if (!UFileSystem::Exists("Config/EditorPreferences.user.json"))
+		if (!UFileSystem::Exists(UserEditorSettingsPath))
 		{
 			std::filesystem::copy_file(
-				"Config/EditorPreferences.json",
-				"Config/EditorPreferences.user.json");
+			DefaultEditorSettingsPath,	
+				UserEditorSettingsPath);
 		}
 		
-		EditorPreferencesDocument = UFileSystem::OpenJson("Config/EditorPreferences.user.json");
+		EditorPreferencesDocument = UFileSystem::OpenJson(UserEditorSettingsPath);
 		
 		EditorPreferences.Sensitivity = EditorPreferencesDocument.Get("Sensitivity", 0.5f);	
 		EditorPreferences.ColorTheme = static_cast<EEditorColorTheme>(EditorPreferencesDocument.Get("Color Theme", 1));

--- a/Havtorn/Source/Editor/EditorManager.cpp
+++ b/Havtorn/Source/Editor/EditorManager.cpp
@@ -236,6 +236,7 @@ namespace Havtorn
 			if (camera->IsActive)
 			{
 				World->SetMainCamera(camera->Owner);
+				SetEditorSensitivity(GetEditorSensitivity());
 				break;
 			}
 		}
@@ -612,6 +613,24 @@ namespace Havtorn
 	{
 		ViewportPadding = padding;
 		InitEditorLayout();
+	}
+
+	F32 CEditorManager::GetEditorSensitivity() const
+	{
+		return EditorSensitivity;
+	}
+
+	void CEditorManager::SetEditorSensitivity(F32 sensitivity)
+	{
+		EditorSensitivity = sensitivity;
+		
+		if (!CurrentWorkingScene) return;
+		if (!World || !World->GetMainCamera().IsValid()) return;
+		
+		SCameraControllerComponent* controllerComp = CurrentWorkingScene->GetComponent<SCameraControllerComponent>(World->GetMainCamera());
+		if (!SComponent::IsValid(controllerComp)) return;
+		
+		controllerComp->RotationSpeed = GetEditorSensitivity();
 	}
 
 	bool CEditorManager::GetIsWorldPlaying() const

--- a/Havtorn/Source/Editor/EditorManager.cpp
+++ b/Havtorn/Source/Editor/EditorManager.cpp
@@ -901,7 +901,14 @@ namespace Havtorn
 
 	void CEditorManager::InitEditorPreferences()
 	{
-		EditorPreferencesDocument = UFileSystem::OpenJson("Config/EditorPreferences.json");
+		if (!UFileSystem::Exists("Config/EditorPreferences.user.json"))
+		{
+			std::filesystem::copy_file(
+				"Config/EditorPreferences.json",
+				"Config/EditorPreferences.user.json");
+		}
+		
+		EditorPreferencesDocument = UFileSystem::OpenJson("Config/EditorPreferences.user.json");
 		
 		EditorPreferences.Sensitivity = EditorPreferencesDocument.Get("Sensitivity", 0.5f);	
 		EditorPreferences.ColorTheme = static_cast<EEditorColorTheme>(EditorPreferencesDocument.Get("Color Theme", 1));

--- a/Havtorn/Source/Editor/EditorManager.cpp
+++ b/Havtorn/Source/Editor/EditorManager.cpp
@@ -101,6 +101,7 @@ namespace Havtorn
 
 		InitEditorLayout();
 		InitAssetRepresentations();
+		InitEditorPreferences();
 
 		return success;
 	}
@@ -203,6 +204,37 @@ namespace Havtorn
 				GUI::Text(GEngine::GetAssetRegistry()->GetDebugString(debugRegistry).c_str());
 			}
 
+			GUI::End();
+		}
+		
+		if (IsPreferenesOpen)
+		{
+			if (GUI::Begin("Editor Preferences", &IsPreferenesOpen))
+			{
+				F32 sensitivity = GetEditorSensitivity();
+				if (GUI::DragFloat("Editor Sensitivity", sensitivity, 0.01f, 0.01f, 5.0f))
+				{
+					SetEditorSensitivity(sensitivity);
+				}
+				
+				GUI::Text("Editor Theme");
+				F32 sz = GUI::GetTextLineHeight();
+				for (U16 i = 0; i < static_cast<U16>(EEditorColorTheme::Count); i++)
+				{
+					auto colorTheme = static_cast<EEditorColorTheme>(i);
+					std::string name = GetEditorColorThemeName(colorTheme).c_str();
+					SVector2<F32> cursorPos = GUI::GetCursorScreenPos();
+					SColor previewColor = GetEditorColorThemeRepColor(colorTheme);
+					GUI::AddRectFilled(cursorPos, SVector2<F32>(sz), previewColor);
+					GUI::Dummy({ sz, sz });
+					GUI::SameLine();
+					if (GUI::MenuItem(name.c_str()))
+					{
+						SetEditorTheme(static_cast<EEditorColorTheme>(i));
+					}
+				}
+			}
+			
 			GUI::End();
 		}
 	}
@@ -472,7 +504,12 @@ namespace Havtorn
 
 	void CEditorManager::SetEditorTheme(EEditorColorTheme colorTheme, EEditorStyleTheme styleTheme)
 	{
-		CurrentColorTheme = colorTheme;
+		if (EditorPreferences.ColorTheme != colorTheme)
+		{
+			EditorPreferencesDocument.Set("Color Theme", static_cast<int>(colorTheme));
+			
+		}
+		EditorPreferences.ColorTheme = colorTheme;
 
 		switch (colorTheme)
 		{
@@ -507,6 +544,63 @@ namespace Havtorn
 				SColor(0.576f, 1.00f, 0.00f, 1.00f)
 			);
 			GUI::SetGuiColorProfile(colorProfile);
+		}
+		break;
+			
+		
+		case EEditorColorTheme::HavtornDarkBlue:
+		{
+		    SGuiColorProfile colorProfile(
+		        SColor(0.11f, 0.11f, 0.11f, 1.00f),
+		        SColor(0.198f, 0.198f, 0.198f, 1.00f),
+		        SColor(0.278f, 0.271f, 0.267f, 1.00f),
+		        SColor(0.188f, 0.278f, 0.478f, 1.00f),
+		        SColor(0.00f, 0.314f, 0.814f, 1.00f),
+		        SColor(0.00f, 0.376f, 1.00f, 1.00f)
+		    );
+		    GUI::SetGuiColorProfile(colorProfile);
+		}
+		break;
+
+		case EEditorColorTheme::HavtornLightBlue:
+		{
+		    SGuiColorProfile colorProfile(
+		        SColor(0.11f, 0.11f, 0.11f, 1.00f),
+		        SColor(0.198f, 0.198f, 0.198f, 1.00f),
+		        SColor(0.278f, 0.271f, 0.267f, 1.00f),
+		        SColor(0.318f, 0.478f, 0.678f, 1.00f),
+		        SColor(0.469f, 0.714f, 0.914f, 1.00f),
+		        SColor(0.576f, 0.824f, 1.00f, 1.00f)
+		    );
+		    GUI::SetGuiColorProfile(colorProfile);
+		}
+		break;
+
+		case EEditorColorTheme::HavtornPurple:
+		{
+		    SGuiColorProfile colorProfile(
+		        SColor(0.11f, 0.11f, 0.11f, 1.00f),
+		        SColor(0.198f, 0.198f, 0.198f, 1.00f),
+		        SColor(0.278f, 0.271f, 0.267f, 1.00f),
+		        SColor(0.361f, 0.278f, 0.478f, 1.00f),
+		        SColor(0.561f, 0.314f, 0.814f, 1.00f),
+		        SColor(0.686f, 0.376f, 1.00f, 1.00f)
+		    );
+		    GUI::SetGuiColorProfile(colorProfile);
+		}
+		break;
+
+		case EEditorColorTheme::HavtornPink:
+		{
+		    SGuiColorProfile colorProfile(
+		        SColor(0.11f, 0.11f, 0.11f, 1.00f),
+		        SColor(0.198f, 0.198f, 0.198f, 1.00f),
+		        SColor(0.278f, 0.271f, 0.267f, 1.00f),
+		        SColor(0.478f, 0.278f, 0.361f, 1.00f),
+		        SColor(0.814f, 0.314f, 0.561f, 1.00f),
+		        SColor(1.00f, 0.376f, 0.686f, 1.00f)
+		    );
+		    GUI::SetGuiColorProfile(colorProfile);
 		}
 		break;
 
@@ -575,6 +669,14 @@ namespace Havtorn
 			return "Havtorn Red";
 		case EEditorColorTheme::HavtornGreen:
 			return "Havtorn Green";
+		case EEditorColorTheme::HavtornDarkBlue:
+			return "Havtorn Dark Blue";
+		case EEditorColorTheme::HavtornLightBlue:
+			return "Havtorn Light Blue";
+		case EEditorColorTheme::HavtornPurple:
+			return "Havtorn Purple";
+		case EEditorColorTheme::HavtornPink:
+			return "Havtorn Pink";
 		case EEditorColorTheme::Count:
 			return {};
 		}
@@ -593,6 +695,14 @@ namespace Havtorn
 			return { 0.478f, 0.188f, 0.188f, 1.00f };
 		case EEditorColorTheme::HavtornGreen:
 			return { 0.355f, 0.478f, 0.188f, 1.00f };
+		case EEditorColorTheme::HavtornDarkBlue:
+			return { 0.11f, 0.18f, 0.32f, 1.00f };
+		case EEditorColorTheme::HavtornLightBlue:
+			return { 0.46f, 0.64f, 0.88f, 1.00f };
+		case EEditorColorTheme::HavtornPurple:
+			return { 0.48f, 0.36f, 0.60f, 1.00f };
+		case EEditorColorTheme::HavtornPink:
+			return { 0.78f, 0.36f, 0.52f, 1.00f };
 		case EEditorColorTheme::Count:
 			return {};
 		}
@@ -617,12 +727,13 @@ namespace Havtorn
 
 	F32 CEditorManager::GetEditorSensitivity() const
 	{
-		return EditorSensitivity;
+		return EditorPreferences.Sensitivity;
 	}
 
 	void CEditorManager::SetEditorSensitivity(F32 sensitivity)
 	{
-		EditorSensitivity = sensitivity;
+		EditorPreferences.Sensitivity = sensitivity;
+		EditorPreferencesDocument.Set("Sensitivity", EditorPreferences.Sensitivity);
 		
 		if (!CurrentWorkingScene) 
 			return;
@@ -664,6 +775,11 @@ namespace Havtorn
 	void CEditorManager::ToggleDemo()
 	{
 		IsDemoOpen = !IsDemoOpen;
+	}
+	
+	void CEditorManager::TogglePreferences()
+	{
+		IsPreferenesOpen = !IsPreferenesOpen;
 	}
 
 	void CEditorManager::InitEditorLayout()
@@ -781,6 +897,15 @@ namespace Havtorn
 
 		//	ResourceManager->ConvertToHVA(fileName, fileName.substr(0, fileName.find_last_of('\\')), assetType);
 		//}
+	}
+
+	void CEditorManager::InitEditorPreferences()
+	{
+		EditorPreferencesDocument = UFileSystem::OpenJson("Config/EditorPreferences.json");
+		
+		EditorPreferences.Sensitivity = EditorPreferencesDocument.Get("Sensitivity", 0.5f);	
+		EditorPreferences.ColorTheme = static_cast<EEditorColorTheme>(EditorPreferencesDocument.Get("Color Theme", 1));
+		SetEditorTheme(EditorPreferences.ColorTheme);
 	}
 
 	void CEditorManager::OnInputSetTransformGizmo(const SInputActionPayload payload)
@@ -955,8 +1080,8 @@ namespace Havtorn
 
 	void CEditorManager::OnBeginPlay(std::vector<Ptr<CScene>>& /*scenes*/)
 	{
-		if (CurrentColorTheme != EEditorColorTheme::PauseMode)
-			CachedColorTheme = CurrentColorTheme;
+		if (EditorPreferences.ColorTheme != EEditorColorTheme::PauseMode)
+			EditorPreferences.CachedColorTheme = EditorPreferences.ColorTheme;
 
 		SetSelectedEntity(SEntity::Null);
 		SetEditorTheme(EEditorColorTheme::PlayMode);
@@ -973,7 +1098,7 @@ namespace Havtorn
 
 	void CEditorManager::OnEndPlay(std::vector<Ptr<CScene>>& /*scenes*/)
 	{
-		SetEditorTheme(CachedColorTheme);
+		SetEditorTheme(EditorPreferences.CachedColorTheme);
 		World->UnblockSystem<CPickingSystem>(this);
 	}
 

--- a/Havtorn/Source/Editor/EditorManager.cpp
+++ b/Havtorn/Source/Editor/EditorManager.cpp
@@ -624,11 +624,14 @@ namespace Havtorn
 	{
 		EditorSensitivity = sensitivity;
 		
-		if (!CurrentWorkingScene) return;
-		if (!World || !World->GetMainCamera().IsValid()) return;
+		if (!CurrentWorkingScene) 
+			return;
+		if (!World || !World->GetMainCamera().IsValid()) 
+			return;
 		
 		SCameraControllerComponent* controllerComp = CurrentWorkingScene->GetComponent<SCameraControllerComponent>(World->GetMainCamera());
-		if (!SComponent::IsValid(controllerComp)) return;
+		if (!SComponent::IsValid(controllerComp)) 
+			return;
 		
 		controllerComp->RotationSpeed = GetEditorSensitivity();
 	}

--- a/Havtorn/Source/Editor/EditorManager.h
+++ b/Havtorn/Source/Editor/EditorManager.h
@@ -157,6 +157,8 @@ namespace Havtorn
 
 		[[nodiscard]] F32 GetViewportPadding() const;
 		void SetViewportPadding(const F32 padding);
+		[[nodiscard]] F32 GetEditorSensitivity() const;
+		void SetEditorSensitivity(F32 sensitivity);
 	
 		bool GetIsWorldPlaying() const;
 
@@ -228,6 +230,7 @@ namespace Havtorn
 		SSnappingOption CurrentGizmoSnapping = {};
 
 		F32 ViewportPadding = 0.2f;
+		F32 EditorSensitivity = 0.5f;
 		bool IsEnabled = true;
 		bool IsDebugInfoOpen = true;
 		bool IsDemoOpen = false;

--- a/Havtorn/Source/Editor/EditorManager.h
+++ b/Havtorn/Source/Editor/EditorManager.h
@@ -39,6 +39,10 @@ namespace Havtorn
 		HavtornDark,
 		HavtornRed,
 		HavtornGreen,
+		HavtornDarkBlue,
+		HavtornLightBlue,
+		HavtornPurple,
+		HavtornPink,
 		Count,
 		PlayMode,
 		PauseMode
@@ -83,6 +87,13 @@ namespace Havtorn
 		bool UsingEditorTexture = false;
 		bool IsSourceWatched = false;
 		bool IsBeingNamed = false;
+	};
+	
+	struct SEditorPreferences
+	{
+		F32 Sensitivity = 0.5f;
+		EEditorColorTheme ColorTheme = EEditorColorTheme::HavtornDark;
+		EEditorColorTheme CachedColorTheme = EEditorColorTheme::HavtornDark;
 	};
 
 	class CEditorManager
@@ -173,6 +184,7 @@ namespace Havtorn
 
 		void ToggleDebugInfo();
 		void ToggleDemo();
+		void TogglePreferences();
 
 		static std::string PreviewMaterial;
 
@@ -181,6 +193,7 @@ namespace Havtorn
 		void ReinitEditorLayout();
 		void InitAssetRepresentations();
 		void PreProcessAssets();
+		void InitEditorPreferences();
 
 		void OnInputSetTransformGizmo(const SInputActionPayload payload);
 		void OnInputToggleFreeCam(const SInputActionPayload payload);
@@ -221,19 +234,18 @@ namespace Havtorn
 
 		// TODO.NR: Save these in .ini file
 		SEditorLayout EditorLayout;
-		EEditorColorTheme CurrentColorTheme = EEditorColorTheme::HavtornDark;
-
-		EEditorColorTheme CachedColorTheme = EEditorColorTheme::HavtornDark;
 
 		ETransformGizmo CurrentGizmo = ETransformGizmo::Translate;
 		ETransformGizmoSpace CurrentGizmoSpace = ETransformGizmoSpace::World;
 		SSnappingOption CurrentGizmoSnapping = {};
+		SEditorPreferences EditorPreferences;
+		 CJsonDocument EditorPreferencesDocument;
 
 		F32 ViewportPadding = 0.2f;
-		F32 EditorSensitivity = 0.5f;
 		bool IsEnabled = true;
 		bool IsDebugInfoOpen = true;
 		bool IsDemoOpen = false;
+		bool IsPreferenesOpen = false;
 		bool IsFreeCamActive = false;
 		bool IsModalOpen = false;
 		bool IsFullscreen = false;

--- a/Havtorn/Source/Editor/EditorManager.h
+++ b/Havtorn/Source/Editor/EditorManager.h
@@ -169,7 +169,7 @@ namespace Havtorn
 		[[nodiscard]] F32 GetViewportPadding() const;
 		void SetViewportPadding(const F32 padding);
 		[[nodiscard]] F32 GetEditorSensitivity() const;
-		void SetEditorSensitivity(F32 sensitivity);
+		void SetEditorSensitivity(const F32 sensitivity);
 	
 		bool GetIsWorldPlaying() const;
 
@@ -245,11 +245,16 @@ namespace Havtorn
 		bool IsEnabled = true;
 		bool IsDebugInfoOpen = true;
 		bool IsDemoOpen = false;
-		bool IsPreferenesOpen = false;
+		bool IsPreferencesOpen = false;
 		bool IsFreeCamActive = false;
 		bool IsModalOpen = false;
 		bool IsFullscreen = false;
 		bool IsDragCopyActive = false;
+	
+		inline static const std::string DefaultEditorSettingsPath =
+		"Config/EditorPreferences.json";
+		inline static const std::string UserEditorSettingsPath =
+		"Config/EditorPreferences.user.json";
 	};
 
 	template<class TEditorWindowType>

--- a/Havtorn/Source/Editor/Toggleables/EditMenu.cpp
+++ b/Havtorn/Source/Editor/Toggleables/EditMenu.cpp
@@ -47,6 +47,17 @@ namespace Havtorn
                 }
                 GUI::EndMenu();
             }
+        	
+        	if (GUI::BeginMenu("Editor Preferences"))
+            {
+            	F32 sensitivity = Manager->GetEditorSensitivity();
+            	if (GUI::DragFloat("Editor Sensitivity", sensitivity, 0.01f, 0.01f, 5.0f))
+            	{
+            		Manager->SetEditorSensitivity(sensitivity);
+            	}
+            	
+            	GUI::EndMenu();
+            }
 
 			GUI::EndPopup();
 		}

--- a/Havtorn/Source/Editor/Toggleables/EditMenu.cpp
+++ b/Havtorn/Source/Editor/Toggleables/EditMenu.cpp
@@ -28,36 +28,12 @@ namespace Havtorn
 		
         if (GUI::BeginPopup(PopupName))
 		{
-            if (GUI::BeginMenu("Editor Themes"))
-            {
-                F32 sz = GUI::GetTextLineHeight();
-                for (U16 i = 0; i < static_cast<U16>(EEditorColorTheme::Count); i++)
-                {
-                    auto colorTheme = static_cast<EEditorColorTheme>(i);
-                    std::string name = Manager->GetEditorColorThemeName(colorTheme).c_str();
-                    SVector2<F32> cursorPos = GUI::GetCursorScreenPos();
-                    SColor previewColor = Manager->GetEditorColorThemeRepColor(colorTheme);
-                    GUI::AddRectFilled(cursorPos, SVector2<F32>(sz), previewColor);
-					GUI::Dummy({ sz, sz });
-                    GUI::SameLine();
-                    if (GUI::MenuItem(name.c_str()))
-                    {
-                        Manager->SetEditorTheme(static_cast<EEditorColorTheme>(i));
-                    }
-                }
-                GUI::EndMenu();
-            }
+        	GUI::Separator();
         	
-        	if (GUI::BeginMenu("Editor Preferences"))
-            {
-            	F32 sensitivity = Manager->GetEditorSensitivity();
-            	if (GUI::DragFloat("Editor Sensitivity", sensitivity, 0.01f, 0.01f, 5.0f))
-            	{
-            		Manager->SetEditorSensitivity(sensitivity);
-            	}
-            	
-            	GUI::EndMenu();
-            }
+        	if(GUI::MenuItem("Editor Preferences"))
+			{
+				Manager->TogglePreferences();
+			}
 
 			GUI::EndPopup();
 		}


### PR DESCRIPTION
Added a slider in Edit->Editor Preferences panel, which allows to adjust global editor sensitivity, that is being applied to editor camera(Main Camera) on any Scene opened